### PR TITLE
Support SSH endpoints and basic auth for HTTP endpoints

### DIFF
--- a/app/scaffold/pkgs/url/url.go
+++ b/app/scaffold/pkgs/url/url.go
@@ -1,0 +1,48 @@
+// Package url contains functions for parsing remote urls
+package url
+
+import (
+	"regexp"
+)
+
+var (
+	isSchemeRegExp = regexp.MustCompile(`^[^:]+://`)
+
+	// Ref: https://github.com/git/git/blob/master/Documentation/urls.txt#L37
+	scpLikeURLRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5}):)?(?P<path>[^\\].*)$`)
+)
+
+// MatchesScheme returns true if the given string matches a URL-like
+// format scheme.
+func MatchesScheme(url string) bool {
+	return isSchemeRegExp.MatchString(url)
+}
+
+// MatchesScpLike returns true if the given string matches an SCP-like
+// format scheme.
+func MatchesScpLike(url string) bool {
+	return scpLikeURLRegExp.MatchString(url)
+}
+
+// IsRemoteEndpoint returns true if the giver URL string specifies
+// a remote endpoint. For example, on a Linux machine,
+// `https://github.com/src-d/go-git` would match as a remote
+// endpoint, but `/home/user/src/go-git` would not.
+func IsRemoteEndpoint(url string) bool {
+	return MatchesScheme(url) || MatchesScpLike(url)
+}
+
+// FindScpLikeComponents returns the user, host, port and path of the
+// given SCP-like URL.
+func FindScpLikeComponents(url string) (user, host, port, path string) {
+	m := scpLikeURLRegExp.FindStringSubmatch(url)
+	return m[1], m[2], m[3], m[4]
+}
+
+// IsLocalEndpoint returns true if the given URL string specifies a
+// local file endpoint.  For example, on a Linux machine,
+// `/home/user/src/go-git` would match as a local endpoint, but
+// `https://github.com/src-d/go-git` would not.
+func IsLocalEndpoint(url string) bool {
+	return !IsRemoteEndpoint(url)
+}

--- a/app/scaffold/pkgs/url/url_test.go
+++ b/app/scaffold/pkgs/url/url_test.go
@@ -1,0 +1,98 @@
+package url
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesScpLike(t *testing.T) {
+	// See https://github.com/git/git/blob/master/Documentation/urls.txt#L37
+	examples := []string{
+		// Most-extended case
+		"git@github.com:james/bond",
+		// Most-extended case with port
+		"git@github.com:22:james/bond",
+		// Most-extended case with numeric path
+		"git@github.com:007/bond",
+		// Most-extended case with port and numeric "username"
+		"git@github.com:22:007/bond",
+		// Single repo path
+		"git@github.com:bond",
+		// Single repo path with port
+		"git@github.com:22:bond",
+		// Single repo path with port and numeric repo
+		"git@github.com:22:007",
+		// Repo path ending with .git and starting with _
+		"git@github.com:22:_007.git",
+		"git@github.com:_007.git",
+		"git@github.com:_james.git",
+		"git@github.com:_james/bond.git",
+	}
+
+	for _, url := range examples {
+		t.Run(url, func(t *testing.T) {
+			assert.Equal(t, true, MatchesScpLike(url))
+		})
+	}
+}
+
+func TestFindScpLikeComponents(t *testing.T) {
+	testCases := []struct {
+		url, user, host, port, path string
+	}{
+		{
+			// Most-extended case
+			url: "git@github.com:james/bond", user: "git", host: "github.com", port: "", path: "james/bond",
+		},
+		{
+			// Most-extended case with port
+			url: "git@github.com:22:james/bond", user: "git", host: "github.com", port: "22", path: "james/bond",
+		},
+		{
+			// Most-extended case with numeric path
+			url: "git@github.com:007/bond", user: "git", host: "github.com", port: "", path: "007/bond",
+		},
+		{
+			// Most-extended case with port and numeric path
+			url: "git@github.com:22:007/bond", user: "git", host: "github.com", port: "22", path: "007/bond",
+		},
+		{
+			// Single repo path
+			url: "git@github.com:bond", user: "git", host: "github.com", port: "", path: "bond",
+		},
+		{
+			// Single repo path with port
+			url: "git@github.com:22:bond", user: "git", host: "github.com", port: "22", path: "bond",
+		},
+		{
+			// Single repo path with port and numeric path
+			url: "git@github.com:22:007", user: "git", host: "github.com", port: "22", path: "007",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:22:_007.git", user: "git", host: "github.com", port: "22", path: "_007.git",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:_007.git", user: "git", host: "github.com", port: "", path: "_007.git",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:_james.git", user: "git", host: "github.com", port: "", path: "_james.git",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:_james/bond.git", user: "git", host: "github.com", port: "", path: "_james/bond.git",
+		},
+	}
+
+	for _, tc := range testCases {
+		user, host, port, path := FindScpLikeComponents(tc.url)
+
+		assert.Equal(t, tc.user, user)
+		assert.Equal(t, tc.host, host)
+		assert.Equal(t, tc.port, port)
+		assert.Equal(t, tc.path, path)
+	}
+}


### PR DESCRIPTION
At the moment, it's challenging to use private git repos as Scaffolds. This change adds two ways to do this:

- Allows users to pass SSH endpoints, like `git@github.com:smoores-dev/scaffold` to `scaffold new`
- Prompts users for HTTP auth credentials (username and password or personal access token) when we receive an `authentication required` error from the git provider.

The new URL tools are ported straight from go-git, and match the way they check and parse URLs.

This fixes #97.