### PR TITLE
fix: try parse computed types

### DIFF
--- a/.examples/types/scaffold.yaml
+++ b/.examples/types/scaffold.yaml
@@ -1,0 +1,19 @@
+questions:
+  - name: langs
+    prompt:
+      multi: true
+      message: "Languages to be used in the project"
+      options:
+        - JavaScript & TypeScript
+        - Python
+
+computed:
+  javascript: '{{ has "JavaScript & TypeScript" .Scaffold.langs }}'
+  python: '{{ has "Python" .Scaffold.langs }}'
+  int: "1"
+  basicint: "{{ add 1 2 }}"
+
+presets:
+  default:
+    Project: "scaffold-test-defaults"
+    langs: ["Python"]

--- a/.examples/types/{{ .ProjectKebab }}/types.txt
+++ b/.examples/types/{{ .ProjectKebab }}/types.txt
@@ -1,0 +1,8 @@
+Has Javascript
+    {{ .Computed.javascript }} (type={{ typeOf .Computed.javascript }})
+Has Python
+    {{ .Computed.python }} (type={{ typeOf .Computed.python }})
+Should Be Int
+    {{ .Computed.int }} (type={{ typeOf .Computed.int }})
+Basic Int
+    {{ .Computed.basicint }} (type={{ typeOf .Computed.basicint }})

--- a/app/commands/runner.go
+++ b/app/commands/runner.go
@@ -53,7 +53,7 @@ func (ctrl *Controller) runscaffold(cfg runconf) error {
 		WriteFS: cfg.outputfs,
 	}
 
-	vars, err = scaffold.BuildVars(ctrl.engine, args, vars)
+	vars, err = scaffold.BuildVars(ctrl.engine, args.Project, vars)
 	if err != nil {
 		return err
 	}

--- a/app/scaffold/render_funcs.go
+++ b/app/scaffold/render_funcs.go
@@ -150,17 +150,17 @@ func guardFeatureFlag(e *engine.Engine, args *RWFSArgs, vars engine.Vars) filepa
 
 // BuildVars builds the vars for the engine by setting the provided vars
 // under the "Scaffold" key and adding the project name and computed vars.
-func BuildVars(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) (engine.Vars, error) {
+func BuildVars(eng *engine.Engine, project *Project, vars engine.Vars) (engine.Vars, error) {
 	iVars := engine.Vars{
-		"Project":      args.Project.Name,
-		"ProjectSnake": xstrings.ToSnakeCase(args.Project.Name),
-		"ProjectKebab": xstrings.ToKebabCase(args.Project.Name),
-		"ProjectCamel": xstrings.ToCamelCase(args.Project.Name),
+		"Project":      project.Name,
+		"ProjectSnake": xstrings.ToSnakeCase(project.Name),
+		"ProjectKebab": xstrings.ToKebabCase(project.Name),
+		"ProjectCamel": xstrings.ToCamelCase(project.Name),
 		"Scaffold":     vars,
 	}
 
-	computed := make(map[string]any, len(args.Project.Conf.Computed))
-	for k, v := range args.Project.Conf.Computed {
+	computed := make(map[string]any, len(project.Conf.Computed))
+	for k, v := range project.Conf.Computed {
 		out, err := eng.TmplString(v, iVars)
 		if err != nil {
 			return nil, err

--- a/app/scaffold/render_funcs.go
+++ b/app/scaffold/render_funcs.go
@@ -166,21 +166,15 @@ func BuildVars(eng *engine.Engine, project *Project, vars engine.Vars) (engine.V
 			return nil, err
 		}
 
-		// try parse bool, we don't use strconv.ParseBool because
-		// we don't want to incorrectly parse an int as a bool so
-		// we will be more strict.
-		switch out {
-		case "true", "TRUE", "True":
-			computed[k] = true
-			continue
-		case "false", "FALSE", "False":
-			computed[k] = false
+		// We must parse the integer first to avoid incorrectly parsing a '0'
+		// as a boolean.
+		if i, err := strconv.Atoi(out); err == nil {
+			computed[k] = i
 			continue
 		}
 
-		// try parse int
-		if i, err := strconv.Atoi(out); err == nil {
-			computed[k] = i
+		if b, err := strconv.ParseBool(out); err == nil {
+			computed[k] = b
 			continue
 		}
 

--- a/app/scaffold/render_funcs_test.go
+++ b/app/scaffold/render_funcs_test.go
@@ -1,0 +1,78 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/hay-kot/scaffold/app/core/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_BuildVars(t *testing.T) {
+	project := &Project{
+		Name: "test",
+		Conf: &ProjectScaffoldFile{
+			Computed: map[string]string{
+				"Bool":     "true",
+				"Int":      "{{ add 1 2 }}",
+				"ZeroInt":  "0",
+				"UsesVars": "Computed: {{ .Scaffold.key }}",
+			},
+		},
+	}
+
+	vars := engine.Vars{
+		"key": "value",
+	}
+
+	eng := engine.New()
+
+	got, err := BuildVars(eng, project, vars)
+	require.NoError(t, err)
+
+	//
+	// Assert Top Level Keys
+	//
+
+	requiredStringKeys := []string{
+		"Project",
+		"ProjectSnake",
+		"ProjectKebab",
+		"ProjectCamel",
+	}
+
+	for _, key := range requiredStringKeys {
+		assert.NotNil(t, got[key])
+		assert.IsType(t, "", got[key])
+	}
+
+	assert.NotNil(t, got["Scaffold"])
+	assert.IsType(t, engine.Vars{}, got["Scaffold"])
+
+	//
+	// Assert Passed in Vars live under Scaffold
+	//
+
+	scaffold := got["Scaffold"].(engine.Vars)
+	assert.NotNil(t, scaffold["key"])
+
+	//
+	// Assert Computed Properties are Typed and Computed
+	//
+
+	require.NotNil(t, got["Computed"])
+	computed := got["Computed"].(map[string]any)
+
+	assert.NotNil(t, computed["Bool"])
+	assert.IsType(t, true, computed["Bool"])
+
+	assert.NotNil(t, computed["Int"])
+	assert.IsType(t, 3, computed["Int"])
+
+	assert.NotNil(t, computed["ZeroInt"])
+	assert.IsType(t, 0, computed["ZeroInt"])
+
+	assert.NotNil(t, computed["UsesVars"])
+	assert.IsType(t, "", computed["UsesVars"])
+	assert.Equal(t, "Computed: value", computed["UsesVars"])
+}

--- a/app/scaffold/snapshot_test.go
+++ b/app/scaffold/snapshot_test.go
@@ -74,7 +74,7 @@ func Test_RenderRWFileSystem(t *testing.T) {
 				Path:     "ROOT_NODE",
 			}
 
-			vars, err := BuildVars(tEngine, args, vars)
+			vars, err := BuildVars(tEngine, args.Project, vars)
 			require.NoError(t, err)
 
 			err = RenderRWFS(tEngine, args, vars)

--- a/docs/docs/scaffold-file.md
+++ b/docs/docs/scaffold-file.md
@@ -135,6 +135,9 @@ You can reference computed variables like so
 {{ .Computed.shuffled }}
 ```
 
+!!! tip
+    Computed variables are generally of type `string` however, there is special handling for boolean and integer types. Scaffold will attempt to parse the resulting string into a boolean, and then an integer.
+
 ### Rewrites
 
 Rewrites working with the [template scaffolds](./index.md#terminology) to perform a path rewrite to another directory. The following example defines a rewrite that will render the `templates/defaults.yaml` file to the `roles/{{ .ProjectKebab }}/defaults/main.yaml` path.

--- a/docs/docs/scaffold-file.md
+++ b/docs/docs/scaffold-file.md
@@ -136,12 +136,8 @@ You can reference computed variables like so
 ```
 
 !!! tip
-    Computed variables are generally of type string however, there is special handling for boolean and integer types. Scaffold will attempt to parse the resulting string into a boolean, and then an integer. 
+    Computed variables are generally of type string however, there are special cases for boolean and integer types. Scaffold will attempt to parse the computed string value into an integer, and then a boolean. If any are successful, that value will be used in-place of the string.
 
-    Boolean parsing is stricker to avoid accidentally parsing an integer into a boolean.
-
-    - `false` `False` and `FALSE` will be corsed into `false`
-    - `true` `True` and `TRUE` will be corsed into `true`
 
 
 ### Rewrites

--- a/docs/docs/scaffold-file.md
+++ b/docs/docs/scaffold-file.md
@@ -136,7 +136,13 @@ You can reference computed variables like so
 ```
 
 !!! tip
-    Computed variables are generally of type `string` however, there is special handling for boolean and integer types. Scaffold will attempt to parse the resulting string into a boolean, and then an integer.
+    Computed variables are generally of type string however, there is special handling for boolean and integer types. Scaffold will attempt to parse the resulting string into a boolean, and then an integer. 
+
+    Boolean parsing is stricker to avoid accidentally parsing an integer into a boolean.
+
+    - `false` `False` and `FALSE` will be corsed into `false`
+    - `true` `True` and `TRUE` will be corsed into `true`
+
 
 ### Rewrites
 

--- a/tests/cli-snapshot.test.sh
+++ b/tests/cli-snapshot.test.sh
@@ -4,7 +4,7 @@
 source tests/assert.sh
 
 # Your script continues as before...
-output=$(go run main.go --log-level="error" \
+output=$($1 --log-level="error" \
     new \
     --preset="default" \
     --no-prompt \

--- a/tests/cli.test.sh
+++ b/tests/cli.test.sh
@@ -3,7 +3,7 @@
 # Source the assertions file
 source tests/assert.sh
 
-go run main.go --log-level="error" \
+$1 --log-level="error" \
     new \
     --preset="default" \
     --no-prompt \

--- a/tests/nested-snapshot.test.sh
+++ b/tests/nested-snapshot.test.sh
@@ -3,8 +3,12 @@
 # Source the assert_snapshot function
 source tests/assert.sh
 
+# accept bin as first argument
+
+
 # Your script continues as before...
-output=$(go run main.go --log-level="error" \
+output=$($1 --log-level="error" \
+    --output-dir=":memory:" \
     new \
     --preset="default" \
     --no-prompt \

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -6,6 +6,9 @@ export SCAFFOLD_DIR=".scaffold,.examples"
 checkmark="✓"
 crossmark="✗"
 
+# build main.go into random temp path
+go build -o /tmp/scaffold-test ./main.go 
+
 echo "Running Script Tests"
 # run each test script in the tests directory
 for test_script in tests/*.test.sh; do
@@ -13,7 +16,7 @@ for test_script in tests/*.test.sh; do
 
     # if exit code of script is 0, print checkmark, else print crossmark
     # and the output indented by 4 spaces
-    output=$($test_script 2>&1)
+    output=$($test_script /tmp/scaffold-test 2>&1)
 
     if [ $? -eq 0 ]; then
         echo "  $checkmark $test_script"

--- a/tests/snapshots/types.snapshot.txt
+++ b/tests/snapshots/types.snapshot.txt
@@ -1,0 +1,11 @@
+scaffold-test-defaults:  (type=dir)
+	types.txt:  (type=file)
+		Has Javascript
+		    false (type=bool)
+		Has Python
+		    true (type=bool)
+		Should Be Int
+		    1 (type=int)
+		Basic Int
+		    3 (type=int)
+		

--- a/tests/types-snapshot.test.sh
+++ b/tests/types-snapshot.test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Source the assert_snapshot function
+source tests/assert.sh
+
+# Your script continues as before...
+output=$($1 --log-level="error" \
+    new \
+    --preset="default" \
+    --no-prompt \
+    --snapshot="stdout" \
+    types)
+
+# Call the function to assert the snapshot
+assert_snapshot "types.snapshot.txt" "$output"


### PR DESCRIPTION
Closes #130

Adds partial support for coercing `Computed` variables into more specific types where possible. Currently only supports boolean and integer types. 