### PR TITLE
feat: Add mode to inject templates after marker

### DIFF
--- a/app/scaffold/injector.go
+++ b/app/scaffold/injector.go
@@ -70,7 +70,6 @@ func Inject(r io.Reader, data string, at string, mode Mode) ([]byte, error) {
 			writelines(lines, indent)
 			inserted = true
 		}
-
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/app/scaffold/injector.go
+++ b/app/scaffold/injector.go
@@ -23,38 +23,55 @@ func indentation(b string) string {
 // Inject will read the reader line by line and find the line
 // that contains the string "at". It will then insert the data
 // before that line.
-func Inject(r io.Reader, data string, at string) ([]byte, error) {
+func Inject(r io.Reader, data string, at string, mode Mode) ([]byte, error) {
 	bldr := strings.Builder{}
 	newline := func(s string) {
 		bldr.WriteString(s)
 		bldr.WriteString("\n")
 	}
 
+	writelines := func(lines []string, indent string) {
+		for _, l := range lines {
+			if l == "" {
+				continue
+			}
+
+			newline(indent + l)
+		}
+
+	}
+
 	found := false
+	after := mode == After
+	inserted := false
 
 	scanner := bufio.NewScanner(r)
+	lines := strings.Split(data, "\n")
+	var indent string
+
 	for scanner.Scan() {
 		line := scanner.Text()
 
+		// Found the line, insert the data
+		// default case will be before
 		if strings.Contains(line, at) {
-			// Found the line, insert the data
-			// before this line
-			indent := indentation(line)
-
-			lines := strings.Split(data, "\n")
-
-			for _, l := range lines {
-				if l == "" {
-					continue
-				}
-
-				newline(indent + l)
+			indent = indentation(line)
+			if mode != After {
+				writelines(lines, indent)
+				inserted = true
 			}
-
 			found = true
 		}
 
 		newline(line)
+
+		// if there is an after mode, insert after!
+		if after && found && !inserted {
+			println("inserting after")
+			writelines(lines, indent)
+			inserted = true
+		}
+
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/app/scaffold/injector.go
+++ b/app/scaffold/injector.go
@@ -38,7 +38,6 @@ func Inject(r io.Reader, data string, at string, mode Mode) ([]byte, error) {
 
 			newline(indent + l)
 		}
-
 	}
 
 	found := false

--- a/app/scaffold/injector_test.go
+++ b/app/scaffold/injector_test.go
@@ -26,6 +26,7 @@ hello world
     indented line
     # Inject After Marker
 `
+
 var t2Want = `---
 hello world
     indented line
@@ -61,7 +62,7 @@ func TestInject(t *testing.T) {
 			args: args{
 				s:    t2,
 				data: "injected line 1\ninjected line 2",
-				at: "# Inject After Marker",
+				at:   "# Inject After Marker",
 				mode: After,
 			},
 			want: t2Want,

--- a/app/scaffold/injector_test.go
+++ b/app/scaffold/injector_test.go
@@ -21,11 +21,25 @@ hello world
     # Inject Marker
 `
 
+var t2 = `---
+hello world
+    indented line
+    # Inject After Marker
+`
+var t2Want = `---
+hello world
+    indented line
+    # Inject After Marker
+    injected line 1
+    injected line 2
+`
+
 func TestInject(t *testing.T) {
 	type args struct {
 		s    string
 		data string
 		at   string
+		mode Mode
 	}
 	tests := []struct {
 		name    string
@@ -43,6 +57,16 @@ func TestInject(t *testing.T) {
 			want: t1Want,
 		},
 		{
+			name: "inject after",
+			args: args{
+				s:    t2,
+				data: "injected line 1\ninjected line 2",
+				at: "# Inject After Marker",
+				mode: After,
+			},
+			want: t2Want,
+		},
+		{
 			name: "inject no marker",
 			args: args{
 				s:    t1,
@@ -54,7 +78,7 @@ func TestInject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Inject(strings.NewReader(tt.args.s), tt.args.data, tt.args.at)
+			got, err := Inject(strings.NewReader(tt.args.s), tt.args.data, tt.args.at, tt.args.mode)
 
 			switch {
 			case tt.wantErr:

--- a/app/scaffold/project_scaffold_file.go
+++ b/app/scaffold/project_scaffold_file.go
@@ -32,14 +32,14 @@ type Mode string
 
 const (
 	Before Mode = "before"
-	After Mode = "after"
+	After  Mode = "after"
 )
 
 type Injectable struct {
 	Name     string `yaml:"name"`
 	Path     string `yaml:"path"`
 	At       string `yaml:"at"`
-	Mode     Mode `yaml:"mode"`
+	Mode     Mode   `yaml:"mode"`
 	Template string `yaml:"template"`
 }
 

--- a/app/scaffold/project_scaffold_file.go
+++ b/app/scaffold/project_scaffold_file.go
@@ -28,10 +28,18 @@ type Rewrite struct {
 	To   string `yaml:"to"`
 }
 
+type Mode string
+
+const (
+	Before Mode = "before"
+	After Mode = "after"
+)
+
 type Injectable struct {
 	Name     string `yaml:"name"`
 	Path     string `yaml:"path"`
 	At       string `yaml:"at"`
+	Mode     Mode `yaml:"mode"`
 	Template string `yaml:"template"`
 }
 

--- a/app/scaffold/render_funcs.go
+++ b/app/scaffold/render_funcs.go
@@ -334,7 +334,7 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 			return err
 		}
 
-		outbytes, err := Inject(f, out, injection.At)
+		outbytes, err := Inject(f, out, injection.At, injection.Mode)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hay-kot/scaffold
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Closes https://github.com/hay-kot/scaffold/issues/127

Adds a mode param that lets user inject code after the marker.

This has proven to be useful if we want to use a more understandable marker such as

```
at: "bob := map[string]Foo{"
```

rather than something more brittle/less understandable than

```
at: "&SomeRandomItemInList{}"
```

Also, in order to have tests pass on my machine, I had to change `go.mod` per instructions here https://github.com/golang/go/issues/65568#issuecomment-1954876836

I can remove this, but I'm not super proficient at Go, so if there's another workaround, happy to remove this commit