### PR TITLE
feat: hooks

### DIFF
--- a/.examples/hooks/hooks/post_scaffold
+++ b/.examples/hooks/hooks/post_scaffold
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+with open("{{ .ProjectKebab }}/file.txt", "a") as f:
+  f.write("Hello\n")

--- a/.examples/hooks/scaffold.yaml
+++ b/.examples/hooks/scaffold.yaml
@@ -1,0 +1,3 @@
+presets:
+  default:
+    Project: "scaffold-test-default"

--- a/.examples/hooks/{{ .ProjectKebab }}/file.txt
+++ b/.examples/hooks/{{ .ProjectKebab }}/file.txt
@@ -1,0 +1,1 @@
+Hook says:

--- a/app/commands/cmd_new.go
+++ b/app/commands/cmd_new.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/hay-kot/scaffold/app/core/fsast"
+	"github.com/hay-kot/scaffold/app/core/rule"
 	"github.com/hay-kot/scaffold/app/scaffold"
 	"github.com/hay-kot/scaffold/app/scaffold/pkgs"
 	"github.com/hay-kot/scaffold/internal/styles"
@@ -17,6 +18,7 @@ import (
 
 type FlagsNew struct {
 	NoPrompt bool
+	RunHooks string
 	Preset   string
 	Snapshot string
 }
@@ -74,6 +76,19 @@ func (ctrl *Controller) New(args []string, flags FlagsNew) error {
 
 			return vars, nil
 		}
+	}
+
+	if flags.RunHooks != "inherit" {
+		runHooks, err := rule.NewFromString(flags.RunHooks)
+		if err != nil {
+			return err
+		}
+
+		ctrl.runHooks = runHooks
+	}
+
+	if ctrl.runHooks == rule.Prompt && flags.NoPrompt {
+		ctrl.runHooks = rule.No
 	}
 
 	outfs := ctrl.Flags.OutputFS()

--- a/app/commands/runner.go
+++ b/app/commands/runner.go
@@ -63,6 +63,11 @@ func (ctrl *Controller) runscaffold(cfg runconf) error {
 		return err
 	}
 
+	err = ctrl.RunHook(pfs, "post_scaffold", cfg.outputfs, vars)
+	if err != nil {
+		return err
+	}
+
 	if cfg.showMessages && p.Conf.Messages.Post != "" {
 		rendered, err := ctrl.engine.TmplString(p.Conf.Messages.Post, vars)
 		if err != nil {

--- a/app/core/rule/rule.go
+++ b/app/core/rule/rule.go
@@ -1,0 +1,69 @@
+// Package rule provides a straightforward and flexible way to handle rule-based
+// logic.
+package rule
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Rule int
+
+const (
+	Unset Rule = iota
+	Yes
+	No
+	Prompt
+)
+
+func NewFromString(s string) (Rule, error) {
+	switch s {
+	case "yes":
+		return Yes, nil
+	case "no":
+		return No, nil
+	case "prompt":
+		return Prompt, nil
+	}
+
+	return Unset, fmt.Errorf("invalid rule: %v", s)
+}
+
+func (r Rule) String() string {
+	switch r {
+	case Unset:
+		return "unset"
+	case Yes:
+		return "yes"
+	case No:
+		return "no"
+	case Prompt:
+		return "prompt"
+	}
+	panic("invalid rule")
+}
+
+func (r *Rule) UnmarshalYAML(node *yaml.Node) error {
+	var asBool bool
+	var asString string
+
+	switch {
+	case node.Decode(&asBool) == nil:
+		if asBool {
+			*r = Yes
+		} else {
+			*r = No
+		}
+		return nil
+	case node.Decode(&asString) == nil:
+		rule, err := NewFromString(asString)
+		if err != nil {
+			return err
+		}
+		*r = rule
+		return nil
+	default:
+		return fmt.Errorf("invalid rule: %v", node.Value)
+	}
+}

--- a/app/core/rwfs/mem.go
+++ b/app/core/rwfs/mem.go
@@ -34,6 +34,10 @@ func (m *MemoryWFS) WriteFile(path string, data []byte, perm fs.FileMode) error 
 	return m.FS.WriteFile(path, data, perm)
 }
 
+func (m *MemoryWFS) RunHook(name string, data []byte, args []string) error {
+	return ErrHooksNotSupported
+}
+
 func NewMemoryWFS() *MemoryWFS {
 	return &MemoryWFS{
 		FS: memfs.New(),

--- a/app/core/rwfs/os.go
+++ b/app/core/rwfs/os.go
@@ -1,8 +1,11 @@
 package rwfs
 
 import (
+	"context"
 	"io/fs"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 )
 
@@ -33,4 +36,53 @@ func (o *OsWFS) MkdirAll(path string, perm fs.FileMode) error {
 // before calling os.WriteFile
 func (o *OsWFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
 	return os.WriteFile(filepath.Join(o.root, name), data, perm)
+}
+
+func (o *OsWFS) RunHook(name string, data []byte, args []string) error {
+	tmp, err := writeHook(name, data)
+
+	defer func() {
+		if rerr := os.Remove(tmp); rerr != nil && err == nil {
+			err = rerr
+		}
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	go func() {
+		// stop receiving signal notifications as soon as possible.
+		<-ctx.Done()
+		stop()
+	}()
+
+	cmd := exec.CommandContext(ctx, tmp, append([]string{tmp}, args...)...)
+	cmd.Dir = o.root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	return err
+}
+
+func writeHook(name string, data []byte) (string, error) {
+	f, err := os.CreateTemp("", name)
+	if err != nil {
+		return "", err
+	}
+
+	tmp := f.Name()
+
+	err = os.Chmod(tmp, 0700)
+	if err != nil {
+		return tmp, err
+	}
+
+	_, err = f.Write(data)
+	if cerr := f.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
+	return tmp, err
 }

--- a/app/core/rwfs/rwfs.go
+++ b/app/core/rwfs/rwfs.go
@@ -3,8 +3,11 @@
 package rwfs
 
 import (
+	"errors"
 	"io/fs"
 )
+
+var ErrHooksNotSupported = errors.New("hooks not supported")
 
 // ReadFS is a read only file system that can be used to read files from
 // a file system. It is a alias for fs.FS.
@@ -16,4 +19,5 @@ type WriteFS interface {
 	fs.FS
 	MkdirAll(path string, perm fs.FileMode) error
 	WriteFile(name string, data []byte, perm fs.FileMode) error
+	RunHook(name string, data []byte, args []string) error
 }

--- a/app/scaffold/rc.go
+++ b/app/scaffold/rc.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/hay-kot/scaffold/app/core/rule"
 	"github.com/hay-kot/scaffold/internal/styles"
 	"gopkg.in/yaml.v3"
 )
@@ -47,6 +48,9 @@ type ScaffoldRC struct {
 	// Auth defines a list of auth entries that can be used to
 	// authenticate with a remote SCM.
 	Auth []AuthEntry `yaml:"auth"`
+
+	// RunHooks defines the behavior when a scaffold defines hooks.
+	RunHooks rule.Rule `yaml:"run_hooks"`
 }
 
 type Settings struct {

--- a/docs/docs/.vitepress/config.mts
+++ b/docs/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default withMermaid(
               text: "File Reference",
               link: "/templates/config-reference",
             },
+            { text: "Hooks", link: "/templates/hooks" },
             {
               text: "Testing Scaffolds",
               link: "/templates/testing-scaffolds",

--- a/docs/docs/templates/hooks.md
+++ b/docs/docs/templates/hooks.md
@@ -1,0 +1,16 @@
+---
+---
+
+# Hooks
+
+Hooks are extensionless files that are stored in the `hooks` subdirectory of your scaffold. They allow you to run scripts at specific points during project generation. They are skipped when the scaffold output directory is an in-memory filesystem or when they are explicitely disabled. The [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) is mandatory and can be set to any interpreter on your system. Template variables are available in the scripts.
+
+Currently, only the `post_scaffold` hook is implemented.
+
+::: tip Working directory
+The scripts' working directory is set to the scaffold output directory.
+:::
+
+## `post_scaffold`
+
+The `post_scaffold` hook is executed after the files have been rendered on the disk, but before the `post` message is printed. It is typically used to fix the formatting of generated files.

--- a/docs/docs/user-guide/scaffold-rc.md
+++ b/docs/docs/user-guide/scaffold-rc.md
@@ -99,3 +99,11 @@ auth:
 ::: tip
 the `match` key supports regular expressions giving you a lot of flexibility in defining your matchers.
 :::
+
+## `run_hooks`
+
+You may disable hooks globally by setting `run_hooks` to `false`, or choose to be prompted before they run by setting it to `prompt`. The `--run-hooks` CLI setting takes precedence.
+
+```yaml
+run_hooks: prompt
+```

--- a/main.go
+++ b/main.go
@@ -188,6 +188,11 @@ func main() {
 						Value: false,
 					},
 					&cli.StringFlag{
+						Name:  "run-hooks",
+						Usage: "run hooks (yes, no, prompt, inherit; default: inherited from scaffoldrc)",
+						Value: "inherit",
+					},
+					&cli.StringFlag{
 						Name:  "preset",
 						Usage: "preset to use for the scaffold",
 						Value: "",
@@ -201,6 +206,7 @@ func main() {
 				Action: func(ctx *cli.Context) error {
 					return ctrl.New(ctx.Args().Slice(), commands.FlagsNew{
 						NoPrompt: ctx.Bool("no-prompt"),
+						RunHooks: ctx.String("run-hooks"),
 						Preset:   ctx.String("preset"),
 						Snapshot: ctx.String("snapshot"),
 					})

--- a/tests/hooks-snapshot.test.sh
+++ b/tests/hooks-snapshot.test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Source the assert_snapshot function
+source tests/assert.sh
+
+# Your script continues as before...
+output=$($1 --log-level="error" \
+    new \
+    --preset="default" \
+    --no-prompt \
+    --snapshot="stdout" \
+    hooks)
+
+# Call the function to assert the snapshot
+assert_snapshot "hooks.snapshot.txt" "$output"

--- a/tests/snapshots/hooks.snapshot.txt
+++ b/tests/snapshots/hooks.snapshot.txt
@@ -1,0 +1,5 @@
+scaffold-test-default:  (type=dir)
+	file.txt:  (type=file)
+		Hook says:
+		Hello
+		


### PR DESCRIPTION
This PR adds an implementation for a `post_scaffold` hook that is run once `RenderRWFS` has been called. I am using it in order to generate lock files for Terraform modules, as well as running formatters on generated files. It also provides a workaround for #136: empty files can be generated using e.g. `touch`.

More hooks can be implemented of course :)

Please let me know what you think when you have time