### PR TITLE
refactor(breaking): refactor flags to be more inline with their commands

### DIFF
--- a/app/commands/cmd_list.go
+++ b/app/commands/cmd_list.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/hay-kot/scaffold/app/scaffold/pkgs"
 	"github.com/hay-kot/scaffold/internal/printer"
-	"github.com/urfave/cli/v2"
 )
 
-func (ctrl *Controller) List(ctx *cli.Context) error {
+type FlagsList struct {
+	OutputDir string
+}
+
+func (ctrl *Controller) List(flags FlagsList) error {
 	systemScaffolds, err := pkgs.ListSystem(os.DirFS(ctrl.Flags.Cache))
 	if err != nil {
 		return err
 	}
 
-	localScaffolds, err := pkgs.ListLocal(os.DirFS(ctrl.Flags.OutputDir))
+	localScaffolds, err := pkgs.ListLocal(os.DirFS(flags.OutputDir))
 	if err != nil {
 		return err
 	}

--- a/app/commands/cmd_new.go
+++ b/app/commands/cmd_new.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -36,7 +37,10 @@ func (f FlagsNew) OutputFS() rwfs.WriteFS {
 
 func (ctrl *Controller) New(args []string, flags FlagsNew) error {
 	if len(args) == 0 {
-		return fmt.Errorf("missing scaffold name")
+		ctrl.printer.FatalError(errors.New("missing scaffold path"))
+		return ctrl.List(FlagsList{
+			OutputDir: flags.OutputDir,
+		})
 	}
 
 	path, err := ctrl.resolve(args[0], flags.OutputDir, flags.NoPrompt, flags.ForceApply)

--- a/app/commands/cmd_new.go
+++ b/app/commands/cmd_new.go
@@ -23,7 +23,6 @@ type FlagsNew struct {
 	NoClobber  bool
 	ForceApply bool
 	OutputDir  string
-	RunHooks   bool
 }
 
 // OutputFS returns a WriteFS based on the OutputDir flag

--- a/app/commands/controller.go
+++ b/app/commands/controller.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/hay-kot/scaffold/app/core/engine"
-	"github.com/hay-kot/scaffold/app/core/rwfs"
 	"github.com/hay-kot/scaffold/app/scaffold/scaffoldrc"
 	"github.com/hay-kot/scaffold/internal/printer"
 	"github.com/hay-kot/scaffold/internal/styles"
@@ -14,21 +13,9 @@ import (
 )
 
 type Flags struct {
-	NoClobber      bool
-	Force          bool
 	ScaffoldRCPath string
 	Cache          string
-	OutputDir      string
 	ScaffoldDirs   []string
-}
-
-// OutputFS returns a WriteFS based on the OutputDir flag
-func (f Flags) OutputFS() rwfs.WriteFS {
-	if f.OutputDir == ":memory:" {
-		return rwfs.NewMemoryWFS()
-	}
-
-	return rwfs.NewOsWFS(f.OutputDir)
 }
 
 type Controller struct {

--- a/app/commands/resolve.go
+++ b/app/commands/resolve.go
@@ -9,15 +9,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (ctrl *Controller) resolve(argPath string, noPrompt bool) (string, error) {
+func (ctrl *Controller) resolve(
+	argPath string,
+	outputdir string,
+	noPrompt bool,
+	force bool,
+) (string, error) {
 	if argPath == "" {
 		return "", fmt.Errorf("path is required")
 	}
 
 	// Status() call for go-git is too slow to be used here
 	// https://github.com/go-git/go-git/issues/181
-	if !ctrl.Flags.Force {
-		ok := checkWorkingTree(ctrl.Flags.OutputDir)
+	if !force {
+		ok := checkWorkingTree(outputdir)
 		if !ok {
 			log.Warn().Msg("working tree is dirty, use --force to apply changes")
 			return "", nil
@@ -54,7 +59,7 @@ func (ctrl *Controller) resolve(argPath string, noPrompt bool) (string, error) {
 				return "", err
 			}
 
-			systemMatches, localMatches, err := ctrl.fuzzyFallBack(argPath)
+			systemMatches, localMatches, err := ctrl.fuzzyFallBack(argPath, outputdir)
 			if err != nil {
 				return "", err
 			}

--- a/app/commands/runner.go
+++ b/app/commands/runner.go
@@ -27,6 +27,7 @@ type runconf struct {
 	varfunc func(*scaffold.Project) (map[string]any, error)
 	// outputdir is the output directory or filesystem.
 	outputfs rwfs.WriteFS
+	options  scaffold.Options
 }
 
 // runscaffold runs the scaffold. This method exists outside of the `new` receiver function
@@ -34,9 +35,7 @@ type runconf struct {
 // as possible.
 func (ctrl *Controller) runscaffold(cfg runconf) error {
 	scaffoldFS := os.DirFS(cfg.scaffolddir)
-	p, err := scaffold.LoadProject(scaffoldFS, scaffold.Options{
-		NoClobber: ctrl.Flags.NoClobber,
-	})
+	p, err := scaffold.LoadProject(scaffoldFS, cfg.options)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func main() {
 			{
 				Name:      "new",
 				Usage:     "create a new project from a scaffold",
-				UsageText: "scaffold new [scaffold (url | path)] [flags]",
+				UsageText: "scaffold new [flags] [scaffold (url | path)]",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:  "no-prompt",
@@ -272,17 +272,16 @@ func main() {
 				Name: "list",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:    "output-dir",
-						Usage:   "scaffold output directory (use ':memory:' for in-memory filesystem)",
-						Value:   ".",
-						EnvVars: []string{"SCAFFOLD_OUT"},
+						Name:  "cwd",
+						Usage: "current working directory to list scaffolds for",
+						Value: ".",
 					},
 				},
 				Aliases: []string{"ls"},
 				Usage:   "list available scaffolds",
 				Action: func(ctx *cli.Context) error {
 					return ctrl.List(commands.FlagsList{
-						OutputDir: ctx.String("output-dir"),
+						OutputDir: ctx.String("cwd"),
 					})
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 				Name:    "theme",
 				Usage:   "theme to use for the scaffold output",
 				Value:   "scaffold",
-				EnvVars: []string{"SCAFFOLD_THEME", "SCAFFOLD_SETTINGS_THEME"},
+				EnvVars: []string{"SCAFFOLD_SETTINGS_THEME", "SCAFFOLD_THEME"},
 			},
 			&cli.StringFlag{
 				Name:    "run-hooks",

--- a/main.go
+++ b/main.go
@@ -76,24 +76,6 @@ func main() {
 				Value:   HomeDir(".scaffold/cache"),
 				EnvVars: []string{"SCAFFOLD_CACHE"},
 			},
-			&cli.BoolFlag{
-				Name:    "no-clobber",
-				Usage:   "do not overwrite existing files",
-				EnvVars: []string{"SCAFFOLD_NO_CLOBBER"},
-				Value:   true,
-			},
-			&cli.BoolFlag{
-				Name:    "force",
-				Usage:   "apply changes when git tree is dirty",
-				Value:   true,
-				EnvVars: []string{"SCAFFOLD_FORCE"},
-			},
-			&cli.StringFlag{
-				Name:    "output-dir",
-				Usage:   "scaffold output directory (use ':memory:' for in-memory filesystem)",
-				Value:   ".",
-				EnvVars: []string{"SCAFFOLD_OUT"},
-			},
 			&cli.StringFlag{
 				Name:    "log-level",
 				Usage:   "log level (debug, info, warn, error, fatal, panic)",
@@ -111,17 +93,9 @@ func main() {
 				Value:   "scaffold",
 				EnvVars: []string{"SCAFFOLD_THEME", "SCAFFOLD_SETTINGS_THEME"},
 			},
-			&cli.StringFlag{
-				Name:    "run-hooks",
-				Usage:   "run hooks (never, always, prompt) when provided overrides scaffold rc",
-				EnvVars: []string{"SCAFFOLD_SETTINGS_RUN_HOOKS"},
-			},
 		},
 		Before: func(ctx *cli.Context) error {
 			ctrl.Flags = commands.Flags{
-				NoClobber:      ctx.Bool("no-clobber"),
-				Force:          ctx.Bool("force"),
-				OutputDir:      ctx.String("output-dir"),
 				Cache:          ctx.String("cache"),
 				ScaffoldRCPath: ctx.String("scaffoldrc"),
 				ScaffoldDirs:   ctx.StringSlice("scaffold-dir"),
@@ -259,20 +233,59 @@ func main() {
 						Usage: "path or `stdout` to save the output ast",
 						Value: "",
 					},
+					&cli.BoolFlag{
+						Name:    "no-clobber",
+						Usage:   "do not overwrite existing files",
+						EnvVars: []string{"SCAFFOLD_NO_CLOBBER"},
+						Value:   true,
+					},
+					&cli.BoolFlag{
+						Name:    "force",
+						Usage:   "apply changes when git tree is dirty",
+						Value:   true,
+						EnvVars: []string{"SCAFFOLD_FORCE"},
+					},
+					&cli.StringFlag{
+						Name:    "output-dir",
+						Usage:   "scaffold output directory (use ':memory:' for in-memory filesystem)",
+						Value:   ".",
+						EnvVars: []string{"SCAFFOLD_OUT"},
+					},
+					&cli.StringFlag{
+						Name:    "run-hooks",
+						Usage:   "run hooks (never, always, prompt) when provided overrides scaffold rc",
+						EnvVars: []string{"SCAFFOLD_SETTINGS_RUN_HOOKS"},
+					},
 				},
 				Action: func(ctx *cli.Context) error {
 					return ctrl.New(ctx.Args().Slice(), commands.FlagsNew{
-						NoPrompt: ctx.Bool("no-prompt"),
-						Preset:   ctx.String("preset"),
-						Snapshot: ctx.String("snapshot"),
+						NoPrompt:   ctx.Bool("no-prompt"),
+						Preset:     ctx.String("preset"),
+						Snapshot:   ctx.String("snapshot"),
+						NoClobber:  ctx.Bool("no-clobber"),
+						ForceApply: ctx.Bool("force"),
+						OutputDir:  ctx.String("output-dir"),
+						RunHooks:   ctx.Bool("run-hooks"),
 					})
 				},
 			},
 			{
-				Name:    "list",
+				Name: "list",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "output-dir",
+						Usage:   "scaffold output directory (use ':memory:' for in-memory filesystem)",
+						Value:   ".",
+						EnvVars: []string{"SCAFFOLD_OUT"},
+					},
+				},
 				Aliases: []string{"ls"},
 				Usage:   "list available scaffolds",
-				Action:  ctrl.List,
+				Action: func(ctx *cli.Context) error {
+					return ctrl.List(commands.FlagsList{
+						OutputDir: ctx.String("output-dir"),
+					})
+				},
 			},
 			{
 				Name:   "update",

--- a/main.go
+++ b/main.go
@@ -93,6 +93,11 @@ func main() {
 				Value:   "scaffold",
 				EnvVars: []string{"SCAFFOLD_THEME", "SCAFFOLD_SETTINGS_THEME"},
 			},
+			&cli.StringFlag{
+				Name:    "run-hooks",
+				Usage:   "run hooks (never, always, prompt) when provided overrides scaffold rc",
+				EnvVars: []string{"SCAFFOLD_SETTINGS_RUN_HOOKS"},
+			},
 		},
 		Before: func(ctx *cli.Context) error {
 			ctrl.Flags = commands.Flags{
@@ -251,11 +256,6 @@ func main() {
 						Value:   ".",
 						EnvVars: []string{"SCAFFOLD_OUT"},
 					},
-					&cli.StringFlag{
-						Name:    "run-hooks",
-						Usage:   "run hooks (never, always, prompt) when provided overrides scaffold rc",
-						EnvVars: []string{"SCAFFOLD_SETTINGS_RUN_HOOKS"},
-					},
 				},
 				Action: func(ctx *cli.Context) error {
 					return ctrl.New(ctx.Args().Slice(), commands.FlagsNew{
@@ -265,7 +265,6 @@ func main() {
 						NoClobber:  ctx.Bool("no-clobber"),
 						ForceApply: ctx.Bool("force"),
 						OutputDir:  ctx.String("output-dir"),
-						RunHooks:   ctx.Bool("run-hooks"),
 					})
 				},
 			},

--- a/tests/hooks-snapshot.test.sh
+++ b/tests/hooks-snapshot.test.sh
@@ -5,11 +5,11 @@ source tests/assert.sh
 
 # Your script continues as before...
 output=$($1 --log-level="error" \
-    --run-hooks="always" \
     new \
     --preset="default" \
     --no-prompt \
     --snapshot="stdout" \
+    --run-hooks="always" \
     hooks)
 
 # Call the function to assert the snapshot

--- a/tests/hooks-snapshot.test.sh
+++ b/tests/hooks-snapshot.test.sh
@@ -5,11 +5,11 @@ source tests/assert.sh
 
 # Your script continues as before...
 output=$($1 --log-level="error" \
+    --run-hooks="always" \
     new \
     --preset="default" \
     --no-prompt \
     --snapshot="stdout" \
-    --run-hooks="always" \
     hooks)
 
 # Call the function to assert the snapshot

--- a/tests/nested-snapshot.test.sh
+++ b/tests/nested-snapshot.test.sh
@@ -8,8 +8,8 @@ source tests/assert.sh
 
 # Your script continues as before...
 output=$($1 --log-level="error" \
-    --output-dir=":memory:" \
     new \
+    --output-dir=":memory:" \
     --preset="default" \
     --no-prompt \
     --snapshot="stdout" \

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 export SCAFFOLD_NO_CLOBBER="true"
 export SCAFFOLD_OUT="gen"
+export SCAFFOLD_CACHE="./scaffold/.cache"
 export SCAFFOLD_DIR=".scaffold,.examples"
 
 checkmark="✓"
 crossmark="✗"
 
-# build main.go into random temp path
+# build main.go into temp path
 go build -o /tmp/scaffold-test ./main.go 
 
 echo "Running Script Tests"


### PR DESCRIPTION
Moves 

- `--no-clobber`
- `--force`
- `--output-dir`

under the `new` command, where they are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command handling for the scaffold application with new flags and options.
	- Introduced `cwd` flag for the `list` command and improved error handling in the `new` command.

- **Bug Fixes**
	- Improved flexibility in command execution through updated method signatures.

- **Chores**
	- Updated test scripts for better clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->