### PR TITLE
fix: use slice copy instead of inline modification

### DIFF
--- a/internal/huhext/loopinput.go
+++ b/internal/huhext/loopinput.go
@@ -69,13 +69,15 @@ func (l *LoopedInput) GetKey() string {
 
 // GetValue implements huh.Field.
 func (l *LoopedInput) GetValue() any {
+	tmp := make([]string, len(l.values))
+	copy(tmp, l.values)
 	lastval := l.input.GetValue().(string)
 
 	if lastval != "" {
-		l.values = append(l.values, lastval)
+		tmp = append(tmp, lastval)
 	}
 
-	return l.values
+	return tmp
 }
 
 // Init implements huh.Field.


### PR DESCRIPTION
## Purpose

When using a looped input and a conditional, the internal slice is modified when using `GetValue` this causes each character to be added to the slice and makes the input unusable. 

## Proposed Changes

  - uses a slice copy in result of `GetValue` instead of direct reference

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved input processing to preserve existing entries while properly appending new, non-empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->