### PR TITLE
feat: support template partials

### DIFF
--- a/app/scaffold/.snapshots/render_rwfs/Test_RenderRWFileSystem-partials.snapshot
+++ b/app/scaffold/.snapshots/render_rwfs/Test_RenderRWFileSystem-partials.snapshot
@@ -1,0 +1,8 @@
+NewProject:  (type=dir)
+	standard.txt:  (type=file)
+		From My Partial, Hello, World!
+		From My Partial, Hello, World!
+		From My Partial, Hello, World!
+		
+		
+

--- a/app/scaffold/main_test.go
+++ b/app/scaffold/main_test.go
@@ -17,6 +17,9 @@ var (
 	//go:embed testdata/projects/custom_delims
 	customDelimsFiles embed.FS
 
+	//go:embed testdata/projects/with_partials
+	partialsFiles embed.FS
+
 	//go:embed testdata/projects/dynamic_files/*
 	// Validates That:
 	//  1. Files are created
@@ -156,6 +159,24 @@ func CustomDelimsProject() *Project {
 					Left:  "[[",
 					Right: "]]",
 				},
+			},
+		},
+	}
+}
+
+func PartialsFiles() fs.FS {
+	f, _ := fs.Sub(partialsFiles, "testdata/projects/with_partials")
+	return f
+}
+
+func PartialsProject() *Project {
+	return &Project{
+		NameTemplate: "{{ .Project }}",
+		Name:         "NewProject",
+		Conf: &ProjectScaffoldFile{
+			Partials: "partials",
+			Computed: map[string]string{
+				"Greeting": "Hello, World!",
 			},
 		},
 	}

--- a/app/scaffold/project_scaffold_file.go
+++ b/app/scaffold/project_scaffold_file.go
@@ -17,6 +17,7 @@ type ProjectScaffoldFile struct {
 	Features   []Feature                 `yaml:"features"`
 	Presets    map[string]map[string]any `yaml:"presets"`
 	Delimiters []Delimiters              `yaml:"delimiters"`
+	Partials   string                    `yaml:"partials"` // Folder containing partials
 }
 
 type Delimiters struct {

--- a/app/scaffold/render_funcs.go
+++ b/app/scaffold/render_funcs.go
@@ -3,6 +3,7 @@ package scaffold
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -198,17 +199,40 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 		guardFeatureFlag(eng, args, vars),
 	}
 
+	if args.Project.Conf.Partials != "" {
+		// Turn partials directory into a FS and then
+		// add it to the engine so partials can be used.
+		partialsFS, err := fs.Sub(args.ReadFS, filepath.Join(args.Project.NameTemplate, args.Project.Conf.Partials))
+		if err != nil {
+			return fmt.Errorf("failed to create partials FS: %w", err)
+		}
+
+		err = eng.RegisterPartialsFS(partialsFS, ".")
+		if err != nil {
+			return fmt.Errorf("failed to register partials FS: %w", err)
+		}
+	}
+
 	err := fs.WalkDir(args.ReadFS, args.Project.NameTemplate, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
+		// Use relative path for matching so that the config writers don't have to
+		// specify every file as **/*.goreleaser.yml instead of just *.goreleaser.yml
+		// to match things at the root of the project file.
+		relativePath := strings.TrimPrefix(path, args.Project.NameTemplate+"/")
+
+		// Always Skip Partials if provided
+		if args.Project.Conf.Partials != "" {
+			if strings.HasPrefix(relativePath, args.Project.Conf.Partials) {
+				log.Debug().Str("path", path).Msg("considered partial, skipping rendering")
+				return nil
+			}
+		}
+
 		if args.Project.Conf != nil && len(args.Project.Conf.Skip) > 0 {
 			for _, pattern := range args.Project.Conf.Skip {
-				// Use relative path for matching so that the config writers don't have to
-				// specify every file as **/*.goreleaser.yml instead of just *.goreleaser.yml
-				// to match things at the root of the project file.
-				relativePath := strings.TrimPrefix(path, args.Project.NameTemplate+"/")
 				match, err := doublestar.PathMatch(pattern, relativePath)
 				if err != nil {
 					return err

--- a/app/scaffold/snapshot_test.go
+++ b/app/scaffold/snapshot_test.go
@@ -2,6 +2,7 @@ package scaffold
 
 import (
 	"io/fs"
+	"maps"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy/v2"
@@ -51,6 +52,11 @@ func Test_RenderRWFileSystem(t *testing.T) {
 			fs:   CustomDelimsFiles(),
 			p:    CustomDelimsProject(),
 		},
+		{
+			name: "partials",
+			fs:   PartialsFiles(),
+			p:    PartialsProject(),
+		},
 	}
 
 	vars := engine.Vars{
@@ -65,9 +71,7 @@ func Test_RenderRWFileSystem(t *testing.T) {
 
 	for _, tt := range tests {
 		if tt.vars != nil {
-			for k, v := range tt.vars {
-				vars[k] = v
-			}
+			maps.Copy(vars, tt.vars)
 		}
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/app/scaffold/testdata/projects/with_partials/{{ .Project }}/partials/mypartial.txt
+++ b/app/scaffold/testdata/projects/with_partials/{{ .Project }}/partials/mypartial.txt
@@ -1,0 +1,1 @@
+From My Partial, {{ .Computed.Greeting }}

--- a/app/scaffold/testdata/projects/with_partials/{{ .Project }}/standard.txt
+++ b/app/scaffold/testdata/projects/with_partials/{{ .Project }}/standard.txt
@@ -1,0 +1,1 @@
+{{ partial "mypartial" . }}{{ partial "mypartial" . }}{{ partial "mypartial" . }}


### PR DESCRIPTION
## To Do's

- [x] Implementation
- [x] Tests
- [ ] Documentation

## Purpose

Fixes #268

This PR introduces support for special "partials" directories. These are pared prior to render the rest of the files and can contain "partial" templates for re-use through the generated files. 

```
{{ partial "mypartial" . }}
```

## Proposed Changes

  - Support new project configuration option for specify named directory for partials (no default, opt-in only)
  - When partials are provided that directory is automatically ignored for output

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
