### PR TITLE
Fix configuration typo and formatting in what-is-scaffold.md.

### DIFF
--- a/docs/docs/introduction/what-is-scaffold.md
+++ b/docs/docs/introduction/what-is-scaffold.md
@@ -28,7 +28,7 @@ What set's Scaffold apart from projects like cookiecutter is the ability to defi
 
 - **Shared remote templates**
 
-  Templates that add files to a project don't have to be nested under `.scaffolds`. For example, if you are building a tool which users can add to existing project and that tool needs configugration, you can host those tool's scaffolds in a remote repository
+  Templates that add files to a project don't have to be nested under `.scaffolds`. For example, if you are building a tool which users can add to existing project and that tool needs configuration, you can host those tool's scaffolds in a remote repository
 
 See the [examples](https://github.com/hay-kot/scaffold/tree/main/.examples) folder for some examples of how to use Scaffold.
 


### PR DESCRIPTION
Fix spelling of configuration

Fixes #

## Purpose

## Proposed Changes

  -
  -
  -

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typo from “configugration” to “configuration” in the Shared remote templates section.
  * Standardized spacing and indentation in the Shared remote templates bullet list for consistent formatting.
  * Adjusted trailing newline formatting for the “Inject snippets into existing files with Scaffold Templates” bullet to align with style guidelines.
  * Improves overall readability and professionalism of the introduction page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->