### PR TITLE
fix(docs): update scaffold.yaml from quickstart to a valid one

### DIFF
--- a/docs/docs/introduction/quick-start.md
+++ b/docs/docs/introduction/quick-start.md
@@ -100,13 +100,14 @@ Basic `scaffold.yml`:
 
 ```yaml
 questions:
-  - name: license
-    type: select
-    message: Select a license
-    options:
-      - MIT
-      - Apache 2.0
-      - GPL
+  - name: "license"
+    prompt:
+      message: "Select a license"
+      default: "MIT"
+      options:
+        - "MIT"
+        - "Apache-2.0"
+        - "GPL-3.0"
 ```
 
 For detailed information on creating scaffolds, see:


### PR DESCRIPTION
## Documentation improvements

Fix the docs to have a valid `scaffold.yaml` in the quickstart. Seems like the current one is outdated.
