### PR TITLE
chore: add Simplified Technical English rule for LLM prose

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,10 @@ Fixes #
 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)
+
+<!--
+If an LLM writes this pull request title, body, or any commit message on the
+branch, use ASD-STE100 Simplified Technical English. Use active voice,
+approved-vocabulary words, sentences of 20 words or fewer, and no gerunds.
+See CONTRIBUTING.md > Writing style.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Writing style
+
+This guidance applies to all contributor prose. It includes pull request
+titles, pull request bodies, and commit messages.
+
+**Human authors**: Write naturally. Use short-to-medium sentences, active
+voice, and direct language. Assume that the reader knows the codebase.
+
+**LLM authors**: Use
+[ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) for all
+text. Use this practical subset:
+
+- Use words from the STE approved-vocabulary dictionary. Technical names that
+  are not in the dictionary can be used as-is, such as `scaffold.yaml`,
+  `scaffoldrc`, `.scaffolds`, and `scaffold update`.
+- Use one word for one meaning. Do not vary synonyms for style.
+- Use active voice only. Do not use passive constructions.
+- Use present or simple past tense. Do not use `-ing` gerunds or participles as
+  nouns.
+- Limit procedures to 20 words per sentence. Limit descriptions to 25 words
+  per sentence.
+- Put one instruction in each sentence.
+- Do not use idioms, metaphors, or hedging.
+
+The goal is text that each reviewer can understand in one read.


### PR DESCRIPTION
## Purpose

Contributors use LLMs to draft pull request text and commit messages. That text is frequently long and indirect, and a reviewer must read it more than once. The repository has no rule that controls it.

## Proposed Changes

  - Add `CONTRIBUTING.md` with a "Writing style" section. Human authors write naturally. LLM authors use [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/), with a practical subset of ten rules. The subset permits repository names such as `scaffold.yaml` and `scaffoldrc`, which the STE dictionary does not contain.
  - Point `.github/PULL_REQUEST_TEMPLATE.md` at that section with an HTML comment. The comment shows the rule to the author in the editor, but the rendered pull request does not show it.

The repository had no contributing guide before this change, so the new file holds only the writing rule. It does not add setup, test, or submission instructions, because a wrong step is worse than no step. A later pull request can add those sections.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
