### PR TITLE
fix: protect existing files and stop 0777 on generated files

### DIFF
--- a/app/scaffold/no_clobber_test.go
+++ b/app/scaffold/no_clobber_test.go
@@ -1,0 +1,216 @@
+package scaffold
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/hay-kot/scaffold/app/core/engine"
+	"github.com/hay-kot/scaffold/app/core/rwfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func readAll(t *testing.T, fsys fs.FS, path string) string {
+	t.Helper()
+
+	bits, err := fs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	return string(bits)
+}
+
+// Test_NoClobber_TemplateScaffoldChecksOutputPath covers the case that made
+// no-clobber useless in a project: guards run against "templates/.env" while the
+// file on disk is ".env", so the guard never matched and overwrote local edits.
+func Test_NoClobber_TemplateScaffoldChecksOutputPath(t *testing.T) {
+	readFS := fstest.MapFS{
+		"scaffold.yaml":     &fstest.MapFile{Data: []byte("questions: []\n")},
+		"templates/.env":    &fstest.MapFile{Data: []byte("GENERATED=true\n")},
+		"templates/new.txt": &fstest.MapFile{Data: []byte("fresh\n")},
+	}
+
+	memFS := rwfs.NewMemoryWFS()
+	require.NoError(t, memFS.WriteFile(".env", []byte("HAND_EDITED=keepme\n"), 0o644))
+
+	project := &Project{
+		NameTemplate: TemplateDirName,
+		Name:         TemplateDirName,
+		Conf:         &ProjectScaffoldFile{},
+		Options:      Options{NoClobber: true},
+	}
+
+	args := &RWFSArgs{ReadFS: readFS, WriteFS: memFS, Project: project}
+
+	vars, err := BuildVars(tEngine, project, engine.Vars{})
+	require.NoError(t, err)
+
+	require.NoError(t, RenderRWFS(tEngine, args, vars))
+
+	assert.Equal(t, "HAND_EDITED=keepme\n", readAll(t, memFS, ".env"),
+		"existing file must survive a re-run")
+	assert.Equal(t, "fresh\n", readAll(t, memFS, "new.txt"),
+		"a collision must not stop the files that follow it")
+}
+
+// Test_NoClobber_ContinuesPastCollision covers the second half of the bug: the
+// guard returned errFileExists into the walk, which aborted the whole render.
+func Test_NoClobber_ContinuesPastCollision(t *testing.T) {
+	readFS := fstest.MapFS{
+		"scaffold.yaml":                    &fstest.MapFile{Data: []byte("questions: []\n")},
+		"{{ .Project }}/a.txt":             &fstest.MapFile{Data: []byte("a from template\n")},
+		"{{ .Project }}/b.txt":             &fstest.MapFile{Data: []byte("b from template\n")},
+		"{{ .Project }}/nested/c.txt":      &fstest.MapFile{Data: []byte("c from template\n")},
+		"{{ .Project }}/nested/deep/d.txt": &fstest.MapFile{Data: []byte("d from template\n")},
+	}
+
+	memFS := rwfs.NewMemoryWFS()
+	require.NoError(t, memFS.MkdirAll("demo", dirPerm))
+	require.NoError(t, memFS.WriteFile("demo/a.txt", []byte("edited\n"), 0o644))
+
+	project := &Project{
+		NameTemplate: "{{ .Project }}",
+		Name:         "demo",
+		Conf:         &ProjectScaffoldFile{},
+		Options:      Options{NoClobber: true},
+	}
+
+	args := &RWFSArgs{ReadFS: readFS, WriteFS: memFS, Project: project}
+
+	vars, err := BuildVars(tEngine, project, engine.Vars{})
+	require.NoError(t, err)
+
+	require.NoError(t, RenderRWFS(tEngine, args, vars))
+
+	assert.Equal(t, "edited\n", readAll(t, memFS, "demo/a.txt"))
+	assert.Equal(t, "b from template\n", readAll(t, memFS, "demo/b.txt"))
+	assert.Equal(t, "c from template\n", readAll(t, memFS, "demo/nested/c.txt"),
+		"an existing output directory must not block the files inside it")
+	assert.Equal(t, "d from template\n", readAll(t, memFS, "demo/nested/deep/d.txt"))
+}
+
+func Test_NoClobber_DisabledOverwrites(t *testing.T) {
+	readFS := fstest.MapFS{
+		"scaffold.yaml":  &fstest.MapFile{Data: []byte("questions: []\n")},
+		"templates/.env": &fstest.MapFile{Data: []byte("GENERATED=true\n")},
+	}
+
+	memFS := rwfs.NewMemoryWFS()
+	require.NoError(t, memFS.WriteFile(".env", []byte("HAND_EDITED=keepme\n"), 0o644))
+
+	project := &Project{
+		NameTemplate: TemplateDirName,
+		Name:         TemplateDirName,
+		Conf:         &ProjectScaffoldFile{},
+		Options:      Options{NoClobber: false},
+	}
+
+	args := &RWFSArgs{ReadFS: readFS, WriteFS: memFS, Project: project}
+
+	vars, err := BuildVars(tEngine, project, engine.Vars{})
+	require.NoError(t, err)
+
+	require.NoError(t, RenderRWFS(tEngine, args, vars))
+
+	assert.Equal(t, "GENERATED=true\n", readAll(t, memFS, ".env"),
+		"--overwrite must still replace the file")
+}
+
+// Test_NoClobber_EachExpansion checks the expanded-file paths, which run through a
+// separate guard loop from the normal walk.
+func Test_NoClobber_EachExpansion(t *testing.T) {
+	readFS := fstest.MapFS{
+		"scaffold.yaml":               &fstest.MapFile{Data: []byte("questions: []\n")},
+		"templates/[services].conf":   &fstest.MapFile{Data: []byte("service={{ .Each.Item }}\n")},
+		"templates/[services]/run.sh": &fstest.MapFile{Data: []byte("# {{ .Each.Item }}\n")},
+	}
+
+	memFS := rwfs.NewMemoryWFS()
+	require.NoError(t, memFS.WriteFile("api.conf", []byte("hand written\n"), 0o644))
+
+	project := &Project{
+		NameTemplate: TemplateDirName,
+		Name:         TemplateDirName,
+		Conf: &ProjectScaffoldFile{
+			Each: []EachConfig{{Var: "services"}},
+		},
+		Options: Options{NoClobber: true},
+	}
+
+	args := &RWFSArgs{ReadFS: readFS, WriteFS: memFS, Project: project}
+
+	vars, err := BuildVars(tEngine, project, engine.Vars{"services": []string{"api", "web"}})
+	require.NoError(t, err)
+
+	require.NoError(t, RenderRWFS(tEngine, args, vars))
+
+	assert.Equal(t, "hand written\n", readAll(t, memFS, "api.conf"))
+	assert.Equal(t, "service=web\n", readAll(t, memFS, "web.conf"))
+	assert.Equal(t, "# api\n", readAll(t, memFS, "api/run.sh"))
+	assert.Equal(t, "# web\n", readAll(t, memFS, "web/run.sh"))
+}
+
+func Test_FilePerm(t *testing.T) {
+	tests := []struct {
+		name string
+		mode fs.FileMode
+		want fs.FileMode
+	}{
+		{name: "plain config stays 0644", mode: 0o644, want: 0o644},
+		{name: "executable template stays executable", mode: 0o755, want: 0o755},
+		{name: "read only source gains owner write", mode: 0o444, want: 0o644},
+		{name: "group and world write are cleared", mode: 0o666, want: 0o644},
+		{name: "world writable executable is narrowed", mode: 0o777, want: 0o755},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsys := fstest.MapFS{"f": &fstest.MapFile{Data: []byte("x"), Mode: tt.mode}}
+
+			entries, err := fs.ReadDir(fsys, ".")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+
+			assert.Equal(t, tt.want, filePerm(entries[0]))
+		})
+	}
+}
+
+func Test_FilePerm_NilEntry(t *testing.T) {
+	assert.Equal(t, defaultFilePerm, filePerm(nil))
+}
+
+// Test_RenderedFilePermissions checks the mode that actually reaches the output,
+// not just the helper. A generated .env used to arrive executable.
+func Test_RenderedFilePermissions(t *testing.T) {
+	readFS := fstest.MapFS{
+		"scaffold.yaml":         &fstest.MapFile{Data: []byte("questions: []\n"), Mode: 0o644},
+		"templates/.env":        &fstest.MapFile{Data: []byte("SECRET=hunter2\n"), Mode: 0o644},
+		"templates/entrypoint":  &fstest.MapFile{Data: []byte("#!/bin/sh\necho {{ .Project }}\n"), Mode: 0o755},
+		"templates/copied.skip": &fstest.MapFile{Data: []byte("{{ not a template\n"), Mode: 0o644},
+	}
+
+	memFS := rwfs.NewMemoryWFS()
+
+	project := &Project{
+		NameTemplate: TemplateDirName,
+		Name:         TemplateDirName,
+		Conf:         &ProjectScaffoldFile{Skip: []string{"*.skip"}},
+	}
+
+	args := &RWFSArgs{ReadFS: readFS, WriteFS: memFS, Project: project}
+
+	vars, err := BuildVars(tEngine, project, engine.Vars{})
+	require.NoError(t, err)
+
+	require.NoError(t, RenderRWFS(tEngine, args, vars))
+
+	for path, want := range map[string]fs.FileMode{
+		".env":        0o644,
+		"entrypoint":  0o755,
+		"copied.skip": 0o644,
+	} {
+		info, err := fs.Stat(memFS, path)
+		require.NoError(t, err, path)
+		assert.Equal(t, want, info.Mode().Perm(), path)
+	}
+}

--- a/app/scaffold/render_funcs.go
+++ b/app/scaffold/render_funcs.go
@@ -172,24 +172,74 @@ func guardRenderPath(s *engine.Engine, vars any) filepathGuard {
 	}
 }
 
+// outputPath resolves the path a file is actually written to. Guards run against
+// the source path, which for a template scaffold still carries the "templates/"
+// prefix that RenderRWFS strips just before writing. Any guard that has to reason
+// about the destination rather than the source must go through this.
+func outputPath(args *RWFSArgs, path string) string {
+	if args.Project.NameTemplate == TemplateDirName {
+		return strings.TrimPrefix(path, TemplateDirName+"/")
+	}
+
+	return path
+}
+
 func guardNoClobber(args *RWFSArgs) filepathGuard {
 	if !args.Project.Options.NoClobber {
 		return guardNoOp
 	}
 
 	return func(outpath string, f fs.DirEntry) (string, error) {
-		wf, err := args.WriteFS.Open(outpath)
-
+		// Test the destination, not the source. Checking the untrimmed path made
+		// this guard a no-op for template scaffolds, which silently overwrote
+		// files the user had edited.
+		wf, err := args.WriteFS.Open(outputPath(args, outpath))
 		if err == nil {
 			_ = wf.Close()
-			if args.Project.Options.NoClobber {
-				log.Debug().Str("path", outpath).Msg("file exists and no-clobber is set to true")
-				return "", errFileExists
-			}
+			log.Debug().Str("path", outpath).Msg("file exists and no-clobber is set to true")
+			return "", errFileExists
 		}
 
 		return outpath, nil
 	}
+}
+
+// isSkip reports whether a guard error means "leave this file alone" rather than
+// "stop rendering". no-clobber is a per-file decision, so a collision must not
+// abandon the files that come after it.
+func isSkip(err error) bool {
+	return errors.Is(err, errSkipRender) ||
+		errors.Is(err, errSkipWrite) ||
+		errors.Is(err, errFileExists)
+}
+
+const (
+	dirPerm          fs.FileMode = 0o755
+	defaultFilePerm  fs.FileMode = 0o644
+	ownerWritePerm   fs.FileMode = 0o600
+	groupWorldWrites fs.FileMode = 0o022
+)
+
+// filePerm derives the mode for a generated file from its template. Scaffold used
+// to write everything as 0777, which made generated .env files executable and
+// world readable. Carrying the template's own bits keeps an executable
+// entrypoint.sh executable while a plain config file stays 0644.
+//
+// The source is normalized rather than copied: owner write is forced on because
+// an embedded FS reports 0444 and a read-only output file is useless, and group
+// and world write are cleared because no generated file needs them.
+func filePerm(d fs.DirEntry) fs.FileMode {
+	if d == nil {
+		return defaultFilePerm
+	}
+
+	info, err := d.Info()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to stat template file, using default permissions")
+		return defaultFilePerm
+	}
+
+	return (info.Mode().Perm() | ownerWritePerm) &^ groupWorldWrites
 }
 
 func guardDirectories(args *RWFSArgs) filepathGuard {
@@ -203,7 +253,7 @@ func guardDirectories(args *RWFSArgs) filepathGuard {
 		// because it is the "templates" directory
 		for _, s := range projectNames {
 			if outpath == s {
-				err := args.WriteFS.MkdirAll(outpath, os.ModePerm)
+				err := args.WriteFS.MkdirAll(outpath, dirPerm)
 				if err != nil {
 					if !os.IsExist(err) {
 						log.Debug().Err(err).Str("path", outpath).Msg("failed to create directory")
@@ -365,7 +415,7 @@ func processFile(eng *engine.Engine, args *RWFSArgs, pf processFileArgs) error {
 		return nil
 	}
 
-	err = args.WriteFS.MkdirAll(filepath.Dir(pf.outpath), os.ModePerm)
+	err = args.WriteFS.MkdirAll(filepath.Dir(pf.outpath), dirPerm)
 	if err != nil {
 		if !os.IsExist(err) {
 			_ = f.Close()
@@ -373,7 +423,7 @@ func processFile(eng *engine.Engine, args *RWFSArgs, pf processFileArgs) error {
 		}
 	}
 
-	err = args.WriteFS.WriteFile(pf.outpath, buff.Bytes(), os.ModePerm)
+	err = args.WriteFS.WriteFile(pf.outpath, buff.Bytes(), filePerm(pf.d))
 	if err != nil {
 		_ = f.Close()
 		return err
@@ -398,7 +448,7 @@ func expandEachDir(eng *engine.Engine, args *RWFSArgs, guards []filepathGuard, s
 		for i, guard := range guards {
 			outpath, err = guard(outpath, d)
 			if err != nil {
-				if errors.Is(err, errSkipRender) || errors.Is(err, errSkipWrite) {
+				if isSkip(err) {
 					return nil
 				}
 				log.Debug().Err(err).Str("outpath", outpath).Int("guard", i).Msg("guard failed")
@@ -406,9 +456,7 @@ func expandEachDir(eng *engine.Engine, args *RWFSArgs, guards []filepathGuard, s
 			}
 		}
 
-		if args.Project.NameTemplate == TemplateDirName {
-			outpath = strings.TrimPrefix(outpath, TemplateDirName+"/")
-		}
+		outpath = outputPath(args, outpath)
 
 		return processFile(eng, args, processFileArgs{
 			sourcePath: path,
@@ -573,7 +621,7 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 					for gi, guard := range iterGuards {
 						outpath, err = guard(outpath, d)
 						if err != nil {
-							if errors.Is(err, errSkipRender) || errors.Is(err, errSkipWrite) {
+							if isSkip(err) {
 								goto nextFileItem
 							}
 							log.Debug().Err(err).Str("outpath", outpath).Int("guard", gi).Msg("guard failed")
@@ -581,9 +629,7 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 						}
 					}
 
-					if args.Project.NameTemplate == TemplateDirName {
-						outpath = strings.TrimPrefix(outpath, TemplateDirName+"/")
-					}
+					outpath = outputPath(args, outpath)
 
 					if err := processFile(eng, args, processFileArgs{
 						sourcePath: path,
@@ -621,23 +667,22 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 				if err != nil {
 					return err
 				}
+				defer rf.Close() //nolint:errcheck
 
 				outpath := path
 				for _, guard := range pathGuards {
 					outpath, err = guard(outpath, d)
 					if err != nil {
-						if errors.Is(err, errFileExists) {
+						if isSkip(err) {
 							return nil
 						}
 						return err
 					}
 				}
 
-				if args.Project.NameTemplate == TemplateDirName {
-					outpath = strings.TrimPrefix(outpath, TemplateDirName+"/")
-				}
+				outpath = outputPath(args, outpath)
 
-				err = args.WriteFS.MkdirAll(filepath.Dir(outpath), os.ModePerm)
+				err = args.WriteFS.MkdirAll(filepath.Dir(outpath), dirPerm)
 				if err != nil {
 					return err
 				}
@@ -647,7 +692,7 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 					return err
 				}
 
-				err = args.WriteFS.WriteFile(outpath, bits, os.ModePerm)
+				err = args.WriteFS.WriteFile(outpath, bits, filePerm(d))
 				if err != nil {
 					return err
 				}
@@ -661,7 +706,7 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 		for i, guard := range guards {
 			outpath, err = guard(outpath, d)
 			if err != nil {
-				if errors.Is(err, errSkipRender) || errors.Is(err, errSkipWrite) {
+				if isSkip(err) {
 					return nil
 				}
 
@@ -672,9 +717,7 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 			log.Debug().Str("outpath", outpath).Int("guard", i).Msg("guard")
 		}
 
-		if args.Project.NameTemplate == TemplateDirName {
-			outpath = strings.TrimPrefix(outpath, TemplateDirName+"/")
-		}
+		outpath = outputPath(args, outpath)
 
 		return processFile(eng, args, processFileArgs{
 			sourcePath: path,
@@ -695,30 +738,46 @@ func RenderRWFS(eng *engine.Engine, args *RWFSArgs, vars engine.Vars) error {
 			return err
 		}
 
-		f, err := args.WriteFS.Open(path)
-		if err != nil {
-			return err
-		}
-
-		out, err := eng.TmplString(injection.Template, vars)
-		if err != nil {
-			return err
-		}
-
-		if out == "" || strings.TrimSpace(out) == "" {
-			continue
-		}
-
-		outbytes, err := Inject(f, out, injection.At, injection.Mode)
-		if err != nil {
-			return err
-		}
-
-		err = args.WriteFS.WriteFile(path, outbytes, os.ModePerm)
-		if err != nil {
+		if err := injectInto(eng, args, injection, path, vars); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// injectInto applies a single injection to an existing file. It is split out of
+// RenderRWFS so the target file handle closes on every path, including the early
+// return for an empty template.
+func injectInto(eng *engine.Engine, args *RWFSArgs, injection Injectable, path string, vars engine.Vars) error {
+	f, err := args.WriteFS.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck
+
+	out, err := eng.TmplString(injection.Template, vars)
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(out) == "" {
+		return nil
+	}
+
+	// The target already exists, so keep the mode it has. Injection edits a file
+	// in place and has no business changing who can read it.
+	perm := defaultFilePerm
+	if info, err := f.Stat(); err == nil {
+		perm = info.Mode().Perm()
+	} else {
+		log.Debug().Err(err).Str("path", path).Msg("failed to stat injection target, using default permissions")
+	}
+
+	outbytes, err := Inject(f, out, injection.At, injection.Mode)
+	if err != nil {
+		return err
+	}
+
+	return args.WriteFS.WriteFile(path, outbytes, perm)
 }


### PR DESCRIPTION
## Purpose

Scaffold destroyed user edits. A user who ran a template scaffold a second time lost the changes in the generated files. Scaffold gave no prompt and no message.

```
scaffold new tpl          # writes .env from templates/.env
echo "KEY=value" >> .env
scaffold new tpl          # on main the edit is gone
```

The `no-clobber` guard tested the source path, which still holds the `templates/` prefix at that point in the guard chain. The destination path has no prefix, so the guard never matched and never protected anything.

Three more defects sit in the same render path. I found them while I read the code around the first one.

## Proposed Changes

  - `no-clobber` tests the destination path, so a template scaffold keeps a file that exists. This changes the behavior for every user. A user who wants the old behavior passes `--overwrite`.
  - A `no-clobber` collision skips one file instead of the full render. The walk treated `errFileExists` as a failure. The first file that exists ended the render, and the files after it were never written. The skip-glob branch already had the correct behavior.
  - A generated file takes the permissions of its template instead of mode 0777. A generated `.env` with a password was executable and world readable. This also changes the behavior for every user: a template with mode 0644 now makes a file with mode 0644.
  - Two leaked file handles close. The skip-glob branch and the injection loop each opened a file and left it open.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
